### PR TITLE
feat: add github actions workflow for lint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,41 @@
+name: Lint
+
+on:
+  push:
+
+jobs:
+
+  get-go-version:
+    name: "Get Go Version 🐹"
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: "Checkout code 🛒"
+        uses: actions/checkout@v3
+
+      - name: "Get Go version from 'go.mod' 📎"
+        id: get-go-version
+        run: |
+          GO_VERSION=$(grep '^go ' go.mod | awk '{print $2}')
+          echo "GO_VERSION=${GO_VERSION}" >> $GITHUB_ENV
+
+  lint:
+    name: "Lint Go code 🐹"
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: "Checkout code 🛒"
+      uses: actions/checkout@v2
+      
+    - name: "Setup Go 🐹"
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.GO_VERSION }}
+
+    - name: "Install dependencies ⤵️"
+      run: go mod download
+
+    - name: "Run Go lint 👓"
+      uses: golangci/golangci-lint-action@v4
+      with:
+        version: v1.54


### PR DESCRIPTION
I was programming in Go and decided to develop a Lint Github Actions Workflow for this project.
I'm not sure if it's useful, but more ideas can come after it.

These workflow steps are:

- Obtaining the Go version from the [go.mod](https://github.com/AndreNovaisBrito/chess-engine/blob/main/go.mod) file of this project to setup the Go version of CI;
- Running [golangCI](https://github.com/golangci/golangci-lint) Github [Action](https://github.com/golangci/golangci-lint-action) that makes various kinds of tests
